### PR TITLE
Fix liquid adaptation and crash with cap enabled

### DIFF
--- a/Shaders/Private/LiquidShaderFillCS.usf
+++ b/Shaders/Private/LiquidShaderFillCS.usf
@@ -36,25 +36,32 @@ void MainCS(uint3 ThreadId : SV_DispatchThreadID)
 		
 		if(CheckHittedNormal(RefTexture[ThreadId.xy].xyz) && !CheckIfHitNormal(uint2(ThreadIdX + 1, ThreadId.y)))
 		{
-			uint2 PixelTemp[2048];
 			for (int i = 1; i < RTargetSize - ThreadIdX; i++)
 			{
-				uint2 PixelPosition = uint2(ThreadIdX + i, ThreadId.y);
+				bool bClear = true;
 
-				PixelTemp[i - 1] = PixelPosition;
-				if( i == RTargetSize - ThreadIdX - 1)
+				for (int i = 1; i <= RTargetSize - ThreadIdX - 1; i++)
 				{
-					for(int j = 0; j <= i - 1; j++)
+					const uint2 PixelPosition = uint2(ThreadIdX + i, ThreadId.y);
+
+					if (CheckIfHitNormal(PixelPosition))
 					{
-						OutputTexture[PixelTemp[j]] = float4(0,0,0,0);
+						bClear = false;
+						break;
 					}
-					break;
+
+					OutputTexture[PixelPosition] = float4(1, 1, 1, 1);
 				}
-					
-				if(CheckIfHitNormal(PixelPosition))
-					break; 
-				
-				OutputTexture[PixelPosition] = float4(1,1,1,1);
+
+				if (bClear)
+				{
+					for (int i = 1; i <= RTargetSize - ThreadIdX - 1; i++)
+					{
+						const uint2 PixelPosition = uint2(ThreadIdX + i, ThreadId.y);
+
+						OutputTexture[PixelPosition] = float4(0, 0, 0, 0);
+					}
+				}
 			}
 		}
 	}

--- a/Source/UTC_LiquidShader/Private/LiquidShaderComponent.cpp
+++ b/Source/UTC_LiquidShader/Private/LiquidShaderComponent.cpp
@@ -478,7 +478,8 @@ void ULiquidShaderComponent::ComputeLiquidVolume(float DeltaTime, bool bInitiali
 	FHitResult LOutHit;
 	FCollisionQueryParams CollisionParams;
 	CollisionParams.bTraceComplex = true;
-
+	CollisionParams.bReturnFaceIndex = true;
+	
 	TArray<FVector2d> VoxelLayers;
 	float MaxLocalBound = SMLiquidOwner->GetBoundingBox().Max.Z * SMComponent->GetComponentScale().Z;
 	float MinLocalBound = SMLiquidOwner->GetBoundingBox().Min.Z * SMComponent->GetComponentScale().Z;
@@ -529,6 +530,7 @@ void ULiquidShaderComponent::ComputeLiquidVolume(float DeltaTime, bool bInitiali
 					else if (bHit)
 					{
 						XIndex += ROutHit.Distance / VoxelSize;
+						RVectorTrace = false;
 					}
 					else
 					{


### PR DESCRIPTION
LiquidSahderFillCS was causing GPU crash due to `OutputTexture[PixelTemp[j]] = float4(0, 0, 0, 0);` so I split the algorithm in two loops.

ComputeLiquidVolume never adjusted the liquid height offset because of the missing `RVectorTrace = false;` if there was a hit but no material was found. The collision setting was missing` bReturnFaceIndex = true` so `ROutHit.FaceIndex` was set to -1.